### PR TITLE
Remove integer cast on sqrt in C#

### DIFF
--- a/sqrt/sqrt.cs
+++ b/sqrt/sqrt.cs
@@ -17,9 +17,9 @@ namespace GetSquare
 
 		}
 
-		private static int getSqr(int toSqr)
+		private static float getSqr(int toSqr)
 		{
-			return (int)Math.Round(Math.Sqrt(toSqr), 2);
+			return Math.Round(Math.Sqrt(toSqr), 2);
 		}
 	}
 }


### PR DESCRIPTION
No reason to cast to integer, sqrt of 5 for example is not a whole number.