### PR TITLE
Deleted using name space std

### DIFF
--- a/helloworld/helloworld.cpp
+++ b/helloworld/helloworld.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
-using namespace std;
 
 int main(){
-  cout << "Hello World" << endl;
+  std::cout << "Hello World" << std::endl;
   return 0;
 }


### PR DESCRIPTION
Better way is to use "std::cout" than "cout" with previous "using namespace std"